### PR TITLE
ci: fix zizmor SARIF upload permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-minor-days: 7
       semver-major-days: 30
     ignore:
@@ -27,7 +27,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-minor-days: 7
       semver-major-days: 30
     groups:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,8 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary
- grant the Zizmor job `security-events: write` so SARIF upload can access CodeQL security-events endpoints on default-branch pushes
- set `persist-credentials: false` on the Zizmor checkout step
- raise Dependabot cooldown `default-days` from 3 to 7 for both Cargo and GitHub Actions updates to satisfy Zizmor's cooldown audit

## Notes
- Investigated failed run: https://github.com/bedecarroll/prompt-assembler/actions/runs/24864052136
- Left `.github/workflows/release.yml` untouched because it is generated by cargo-dist.

## Validation
- `mise run fmt`
- `mise run clippy`
- `mise run unit`
- `mise run lint`
